### PR TITLE
Prepare workflows for Homebrew deployment.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,23 +1,36 @@
-name: Rust
+name: Build
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
 env:
   CARGO_TERM_COLOR: always
+  FILE_NAME: resfetch-mac.tar.gz
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - name: Checkout
       uses: actions/checkout@v3
       
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --release --verbose
       
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --release --verbose
+
+    - name: Compress
+      run: cd target/release && tar -czf $FILE_NAME resfetch
+
+    - name: Upload to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/$FILE_NAME
+        tag: ${{ github.ref }}
+        overwrite: true
+        file_glob: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,4 +33,3 @@ jobs:
         file: target/release/$FILE_NAME
         tag: ${{ github.ref }}
         overwrite: true
-        file_glob: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,23 @@
+name: Rust
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      
+    - name: Build
+      run: cargo build --verbose
+      
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  FILE_NAME: resfetch-mac.tar.gz
 
 jobs:
   build:
@@ -24,12 +23,12 @@ jobs:
       run: cargo test --release --verbose
 
     - name: Compress
-      run: cd target/release && tar -czf $FILE_NAME resfetch
+      run: cd target/release && tar -czf resfetch-mac.tar.gz resfetch
 
     - name: Upload to release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/release/$FILE_NAME
+        file: target/release/resfetch-mac.tar.gz
         tag: ${{ github.ref }}
         overwrite: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,7 +463,7 @@ checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "resfetch"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
  "colored",
  "libmacchina",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resfetch"
-version = "1.0.1"
-authors = ["furtidev <megaphone@poto.cafe>"]
+version = "1.0.2"
+authors = ["furtidev <megaphone@poto.cafe>", "HitBlast <hitblastlive@gmail.com>"]
 edition = "2021"
 description = "A fast and minimal alternative to neofetch"
 keywords = ["system", "neofetch", "fetch", "sysfetch", "cli"]


### PR DESCRIPTION
### This PR adds:

- [x] A new [GitHub Actions](https://github.com/features/actions) workflow to prepare the resfetch package for deployment on [homebrew](https://brew.sh/), one of the most popular macOS package managers out there.